### PR TITLE
Add dark mode toggle

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -38,6 +38,15 @@
   --padding-container-vertical: 3rem;
 }
 
+/* Dark mode overrides */
+body.dark-mode {
+  --color-background: #0d1117;
+  --color-text: #c9d1d9;
+  --color-link: #c9d1d9;
+  --color-link-hover: #ffffff;
+  --color-divider: #30363d;
+}
+
 /* ===== BASE STYLES ===== */
 html {
   font-size: var(--font-size-base);
@@ -192,6 +201,23 @@ td:last-child {
 
 .social-links .label {
   display: none;
+}
+
+/* Dark mode toggle button */
+#theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+#theme-toggle svg {
+  width: 1em;
+  height: 1em;
+  stroke: currentColor;
 }
 
 /* ===== RESPONSIVE STYLES ===== */

--- a/index.html
+++ b/index.html
@@ -24,8 +24,10 @@
     
     <!-- CSS -->
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script src="https://unpkg.com/lucide@latest"></script>
 </head>
 <body>
+    <button id="theme-toggle" aria-label="Toggle dark mode"><i data-lucide="moon"></i></button>
     <div id="wrapper">
         <main id="main">
             <div class="inner">
@@ -206,5 +208,24 @@
             </div>
         </main>
     </div>
+    <script>
+        const toggle = document.getElementById('theme-toggle');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+        const stored = localStorage.getItem('theme');
+        if (stored === 'dark' || (!stored && prefersDark.matches)) {
+            document.body.classList.add('dark-mode');
+            toggle.setAttribute('data-lucide', 'sun');
+        } else {
+            toggle.setAttribute('data-lucide', 'moon');
+        }
+        lucide.createIcons();
+        toggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+            const isDark = document.body.classList.contains('dark-mode');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            toggle.setAttribute('data-lucide', isDark ? 'sun' : 'moon');
+            lucide.createIcons();
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable dark mode variables in CSS
- style and position a toggle button
- add dark-mode switcher button and script in index.html
- swap Unicode icons with Lucide icons

## Testing
- `git status --short`
