### PR TITLE
Fix dark mode icons with Lucide

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
-    <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    <button id="theme-toggle" aria-label="Toggle dark mode"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-moon"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
     <div id="wrapper">
         <main id="main">
             <div class="inner">
@@ -208,21 +208,28 @@
         </main>
     </div>
     <script>
-        const toggle = document.getElementById('theme-toggle');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-        const stored = localStorage.getItem('theme');
-        if (stored === 'dark' || (!stored && prefersDark.matches)) {
-            document.body.classList.add('dark-mode');
-            toggle.innerHTML = '&#x2600;&#xFE0F;';
-        } else {
-            toggle.innerHTML = '&#x1F319;';
-        }
-        toggle.addEventListener('click', () => {
-            document.body.classList.toggle('dark-mode');
-            const isDark = document.body.classList.contains('dark-mode');
-            localStorage.setItem('theme', isDark ? 'dark' : 'light');
-            toggle.innerHTML = isDark ? '&#x2600;&#xFE0F;' : '&#x1F319;';
-        });
+const sunIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-sun"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'; 
+const moonIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-moon"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+const toggle = document.getElementById('theme-toggle');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const stored = localStorage.getItem('theme');
+
+function setIcon(isDark) {
+    toggle.innerHTML = isDark ? sunIcon : moonIcon;
+}
+
+const isInitialDark = stored === 'dark' || (!stored && prefersDark.matches);
+if (isInitialDark) {
+    document.body.classList.add('dark-mode');
+}
+setIcon(isInitialDark);
+
+toggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const isDark = document.body.classList.contains('dark-mode');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    setIcon(isDark);
+});
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- swap emoji dark/light mode toggle for Lucide icons
- update theme toggle script to use Sun and Moon SVGs

## Testing
- `npm test` *(fails: Could not read package.json)*