### PR TITLE
Fix Twitter Icon and Update Theme Toggle Colors

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -48,6 +48,17 @@ body.dark-mode {
   --color-divider: #30363d;
 }
 
+/* Make sure theme toggle icon matches social icon color in dark mode */
+body.dark-mode #theme-toggle-icon {
+  color: var(--color-text-secondary);
+  stroke: var(--color-text-secondary);
+}
+body.dark-mode .icon-btn:hover #theme-toggle-icon,
+body.dark-mode .icon-btn:focus-visible #theme-toggle-icon {
+  color: var(--color-link-hover);
+  stroke: var(--color-link-hover);
+}
+
 /* ==== Tabs & Tab Content Dark Mode ==== */
 body.dark-mode .content {
   background-color: #161b22;
@@ -384,6 +395,13 @@ body {
   color: var(--color-link-hover);
   outline: none;
 }
+
+/* Ensure theme icon inherits same hover/focus color as icon-btn */
+#theme-toggle:hover #theme-toggle-icon,
+#theme-toggle:focus-visible #theme-toggle-icon {
+  color: var(--color-link-hover);
+  stroke: var(--color-link-hover);
+}
 .icon-btn .relative {
   display: flex;
   align-items: center;
@@ -391,13 +409,15 @@ body {
   width: 100%;
   height: 100%;
 }
-.icon-btn svg {
+.icon-btn svg, #theme-toggle-icon {
   display: block;
   margin: auto;
   width: 1.5rem;
   height: 1.5rem;
   vertical-align: middle;
   stroke: currentColor;
+  color: inherit;
+  transition: color 0.2s, stroke 0.2s;
 }
 .actions {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -24,7 +24,8 @@
             </button>
             <a href="https://x.com/bentossell/" target="_blank" rel="noopener" aria-label="X" class="icon-btn">
                 <div class="relative">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-twitter-icon lucide-twitter"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53A4.48 4.48 0 0 0 16.89.64a4.48 4.48 0 0 1-7.86 3v1A10.66 10.66 0 0 1 3 1s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"/></svg>
+                    <!-- Official Lucide Twitter SVG -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-twitter" viewBox="0 0 24 24"><path d="M22 4.01c-.75.35-1.56.59-2.41.7A4.16 4.16 0 0 0 21.44 2c-.81.48-1.7.83-2.65 1.02A4.13 4.13 0 0 0 12 7.11c0 .32.04.64.1.94C8.28 7.89 5.1 6.1 2.99 3.61c-.35.6-.55 1.29-.55 2.02 0 1.39.71 2.62 1.78 3.34-.66-.02-1.28-.2-1.82-.5v.05c0 1.94 1.4 3.57 3.25 3.94-.34.09-.7.14-1.07.14-.26 0-.5-.03-.75-.07.51 1.58 2 2.73 3.76 2.76A8.3 8.3 0 0 1 2 19.54a11.73 11.73 0 0 0 6.29 1.85c7.55 0 11.69-6.26 11.69-11.7l-.01-.53A8.07 8.07 0 0 0 22 4.01Z"/></svg>
                 </div>
             </a>
             <a href="https://www.linkedin.com/in/ben-tossell-70453537/" target="_blank" rel="noopener" aria-label="LinkedIn" class="icon-btn">
@@ -39,7 +40,7 @@
             </a>
             <button id="theme-toggle" aria-label="Toggle dark mode" class="icon-btn" type="button">
                 <div class="relative">
-                    <svg id="theme-toggle-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-moon-icon lucide-moon"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z"/></svg>
+                    <svg id="theme-toggle-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-moon-icon lucide-moon" style="transition: color 0.2s;"><path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z"/></svg>
                 </div>
             </button>
         </div>


### PR DESCRIPTION
This pull request addresses the issue with the Twitter icon appearance by replacing it with the official Lucide Twitter SVG. Additionally, it ensures that the theme toggle icon matches the color scheme of the social icons in both dark and light modes. The hover and focus states for the theme toggle icon have also been updated to inherit the same colors as the social icons, providing a consistent user experience. Changes were made in `assets/css/styles.css` for styling and in `index.html` for the icon replacement.

---

> This pull request was co-created with Cosine Genie

Original Task: [bentossell/jrnmblyzslse](https://cosine.sh/pi4u8gpaokfv/bentossell/task/jrnmblyzslse)
Author: Ben Tossell
