### PR TITLE
Remove irrelevant food content

### DIFF
--- a/food.md
+++ b/food.md
@@ -1,2 +1,0 @@
-### food i like
-- tacos

--- a/index.html
+++ b/index.html
@@ -71,7 +71,6 @@
             <div class="tabs">
                 <button class="tab-trigger active" data-tab="investments">investments</button>
                 <button class="tab-trigger" data-tab="tools">tools i use</button>
-                <button class="tab-trigger" data-tab="food">food i like</button>
                 <button class="tab-trigger" data-tab="blog">blog</button>
             </div>
             <div class="tab-content active" id="investments">
@@ -87,13 +86,6 @@
                     <div class="badges"><span class="badge green">+0</span><span class="badge red">-0</span></div>
                 </div>
                 <div class="diff-block" id="tools-content">Select a tab to load</div>
-            </div>
-            <div class="tab-content" id="food">
-                <div class="file-header">
-                    <button class="file-btn"><svg viewBox="0 0 16 16"><path d="M3.75 1.5a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V4.664a.25.25 0 00-.073-.177l-2.914-2.914a.25.25 0 00-.177-.073H3.75zM2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16h-9.5A1.75 1.75 0 012 14.25V1.75z"></path><path d="M4.75 4a.75.75 0 01.75.75v2.5a.75.75 0 01-1.5 0v-2.5A.75.75 0 014.75 4zm4.25 0a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5H9z"></path></svg><span>food.md</span></button>
-                    <div class="badges"><span class="badge green">+0</span><span class="badge red">-0</span></div>
-                </div>
-                <div class="diff-block" id="food-content">Select a tab to load</div>
             </div>
             <div class="tab-content" id="blog">
                 <div class="file-header">
@@ -133,12 +125,6 @@
                             <kbd>t</kbd>
                         </div>
                         <div class="shortcut-description">Go to Tools tab</div>
-                    </div>
-                    <div class="shortcut-item">
-                        <div class="shortcut-keys">
-                            <kbd>f</kbd>
-                        </div>
-                        <div class="shortcut-description">Go to Food tab</div>
                     </div>
                     <div class="shortcut-item">
                         <div class="shortcut-keys">
@@ -284,8 +270,6 @@
             loadMarkdown("investments.md","investments-content");
         }else if(tab === "tools"){
             loadMarkdown("tools.md","tools-content");
-        }else if(tab === "food"){
-            loadMarkdown("food.md","food-content");
         }else if(tab === "blog"){
             loadBlogIndex("blog-content");
         }
@@ -434,10 +418,6 @@
         // 't' to navigate to tools tab
         else if (event.key === 't' && !commandPalette.classList.contains('active')) {
             navigateToTab('tools');
-        }
-        // 'f' to navigate to food tab
-        else if (event.key === 'f' && !commandPalette.classList.contains('active')) {
-            navigateToTab('food');
         }
         // 'b' to navigate to blog tab
         else if (event.key === 'b' && !commandPalette.classList.contains('active')) {


### PR DESCRIPTION
The `food.md` file, containing minimal content, was removed.

Corresponding changes were made in `index.html` to eliminate all references to the "food" section:

*   The "food i like" tab button was removed from the navigation.
*   The entire `div` element for the "food" tab content was deleted.
*   The keyboard shortcut reference for the 'f' key, which navigated to the Food tab, was removed from the shortcuts list.
*   The `handleTabChange` function was updated to remove the `else if (tab === "food")` condition and its associated `loadMarkdown` call.
*   The event listener for the 'f' key, which triggered navigation to the "food" tab, was removed from the global keyboard shortcuts.

These changes ensure the complete removal of the "food" section and its functionality from the website.