### PR TITLE
Add agents.md and link from README (Droid-assisted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 - scouted for a16z and invested in; gamma, cosine, julius.ai, lex, texel, and llamaindex
 - led the product hunt community & homepage, testing 1000s of products along the way
 - lived in china when I was in uni
+- see [agents](agents.md) for my available assistants/agents

--- a/agents.md
+++ b/agents.md
@@ -1,30 +1,34 @@
-# Agents
+# Agents (bentossell/bentossell)
 
-This repo tracks the assistants powering my knowledge system. For context on the wider project see the [README](README.md).
+Agents that operate on this repo (personal site + blog). For broader context see the [README](README.md).
 
 ## Available Agents
 
 ### knowledge-graph-maintainer
-- Purpose: keeps docs in sync; updates `CLAUDE.md` + directory `.md` files when files move, rename, or new agents appear.  
-- When to use: any structural change (create/move/rename) or adding an agent.  
-- Inputs: file/folder events, new-agent definitions.  
-- Outputs: updated markdown docs, commit/PR notes.
+- Scope (this repo): keep docs, links, and indices in sync across `blog/`, `assets/`, and root docs.  
+- When to use: after creating/moving/renaming files; after adding a blog post.  
+- Inputs: changed paths (e.g., `blog/posts/*.md`, `blog/index.md`, `BLOG.md`, `tools.md`, `investments.md`, `assets/images/*`).  
+- Actions/Outputs: verify/update bi-directional links; ensure new posts appear in `blog/index.md` (or fix if `create-post.js` missed it); cross-link new/edited docs; open a small PR.
 
 ### documentation-specialist
-- Purpose: researches + writes clear, complete project docs.  
-- When to use: need deep docs, API refs, or synthesis.  
-- Inputs: raw code, specs, questions.  
-- Outputs: concise markdown docs, diagrams, examples.
+- Scope (this repo): author/edit `BLOG.md`, `tools.md`, `investments.md`, and improve `README.md`.  
+- When to use: need clear docs, guides, or cleanup.  
+- Inputs: prompts, repo files, notes.  
+- Outputs: concise markdown with cross-links and examples relevant to this site.
 
-## Conventions
-- Bi-directional links: if A links to B, B must link to A.  
-- New agents: add entry here and cross-link related docs.  
-- Keep docs short, actionable; prefer lists > prose.
+## Automations in this repo
+- `create-post.js` — blog post generator. Run `npm run new-post` or `node create-post.js`. It creates `blog/posts/YYYY-MM-DD-slug.md` and updates `blog/index.md`. See [BLOG](BLOG.md).  
+- After generating a post, run knowledge-graph-maintainer to validate links and indices.
 
-## How to add a new agent
-1. Define purpose, inputs, outputs.  
+## Conventions (repo-specific)
+- Bi-directional links: if A links to B, add a link back from B → A (e.g., `README.md` ↔ `agents.md`).  
+- Blog: `blog/index.md` lists posts; each post should include a simple “Back to Blog” footer (recommended).  
+- New docs: keep them short/actionable and cross-link from relevant pages.
+
+## How to add a new agent (for this repo)
+1. Define scope, purpose, inputs, outputs for this repo.  
 2. Add an H3 entry under “Available Agents”.  
-3. Link agents.md ↔ relevant files (e.g., README).  
+3. Cross-link `agents.md` ↔ relevant files (e.g., `README.md`, `BLOG.md`).  
 4. Open a small PR.
 
 ---

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,32 @@
+# Agents
+
+This repo tracks the assistants powering my knowledge system. For context on the wider project see the [README](README.md).
+
+## Available Agents
+
+### knowledge-graph-maintainer
+- Purpose: keeps docs in sync; updates `CLAUDE.md` + directory `.md` files when files move, rename, or new agents appear.  
+- When to use: any structural change (create/move/rename) or adding an agent.  
+- Inputs: file/folder events, new-agent definitions.  
+- Outputs: updated markdown docs, commit/PR notes.
+
+### documentation-specialist
+- Purpose: researches + writes clear, complete project docs.  
+- When to use: need deep docs, API refs, or synthesis.  
+- Inputs: raw code, specs, questions.  
+- Outputs: concise markdown docs, diagrams, examples.
+
+## Conventions
+- Bi-directional links: if A links to B, B must link to A.  
+- New agents: add entry here and cross-link related docs.  
+- Keep docs short, actionable; prefer lists > prose.
+
+## How to add a new agent
+1. Define purpose, inputs, outputs.  
+2. Add an H3 entry under “Available Agents”.  
+3. Link agents.md ↔ relevant files (e.g., README).  
+4. Open a small PR.
+
+---
+
+Back to the [README](README.md) • 2025-09-21


### PR DESCRIPTION
Summary\n- Adds agents.md documenting available agents and conventions\n- Adds bi-directional link from README -> agents.md\n\nValidation\n- Git synced (ff-only)\n- No dependencies to install; toolchains: node v20.12.1, npm 10.5.0, python3 3.10.13\n- No lint/tests/build scripts configured in package.json\n\nNotes\n- Minimal, concise content in Ben’s preferred style\n- Bi-directional links respected (agents.md ↔ README.md)