### PR TITLE
feat: add retro mini music player (retro-sound chiptune loops)

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -408,6 +408,205 @@ body {
 .icon-btn:focus-visible {
   background-color: var(--color-divider);
   color: var(--color-link-hover);
+}
+.retro-miniplayer {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 1000;
+  font-family: 'Press Start 2P', monospace;
+  user-select: none;
+}
+
+.retro-chassis {
+  width: 290px;
+  border-radius: 12px;
+  padding: 10px 10px 12px;
+  background: linear-gradient(180deg, #f9f9f9 0%, #e9e9e9 100%);
+  border: 2px solid #c9c9c9;
+  box-shadow:
+    inset 0 2px 0 rgba(255,255,255,0.8),
+    0 8px 24px rgba(0,0,0,0.18),
+    0 4px 10px rgba(0,0,0,0.08);
+}
+
+body.dark-mode .retro-chassis {
+  background: linear-gradient(180deg, #2b2b2b 0%, #1e1e1e 100%);
+  border-color: #3a3a3a;
+  box-shadow:
+    inset 0 2px 0 rgba(255,255,255,0.05),
+    0 8px 24px rgba(0,0,0,0.5),
+    0 4px 10px rgba(0,0,0,0.35);
+}
+
+.retro-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.retro-title {
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #333;
+}
+body.dark-mode .retro-title { color: #e6e6e6; }
+
+.retro-led {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #6b6b6b;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.5);
+}
+
+/* LED when playing */
+.retro-miniplayer.playing .retro-led {
+  background: #46e07f;
+  box-shadow:
+    0 0 4px rgba(70, 224, 127, 0.9),
+    0 0 10px rgba(70, 224, 127, 0.6),
+    inset 0 1px 0 rgba(255,255,255,0.6);
+  animation: led-blink 1.2s infinite ease-in-out;
+}
+@keyframes led-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .6; }
+}
+
+.retro-display {
+  height: 38px;
+  border-radius: 8px;
+  background: linear-gradient(180deg, #101c14 0%, #0b140f 100%);
+  border: 1px solid #254a2f;
+  color: #9af0b8;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  margin-bottom: 10px;
+  text-shadow: 0 0 6px rgba(154, 240, 184, 0.65);
+  overflow: hidden;
+}
+
+.retro-display span {
+  font-size: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.retro-controls {
+  display: grid;
+  grid-template-columns: auto auto auto 1fr;
+  align-items: center;
+  gap: 8px;
+}
+
+.retro-btn {
+  appearance: none;
+  border: 0;
+  border-radius: 8px;
+  height: 36px;
+  width: 44px;
+  font: inherit;
+  font-size: 14px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #1a1a1a;
+  background: linear-gradient(180deg, #ffffff 0%, #dcdcdc 100%);
+  border: 1px solid #bdbdbd;
+  box-shadow: 0 2px 0 #b0b0b0, inset 0 1px 0 rgba(255,255,255,0.8);
+  cursor: pointer;
+  transition: transform .06s ease, box-shadow .06s ease;
+}
+
+.retro-btn:active {
+  transform: translateY(1px);
+  box-shadow: 0 1px 0 #b0b0b0, inset 0 1px 0 rgba(255,255,255,0.7);
+}
+
+.retro-btn.primary {
+  background: linear-gradient(180deg, #ffd36e 0%, #ffb12e 100%);
+  border-color: #cc8c25;
+  box-shadow: 0 2px 0 #b4771f, inset 0 1px 0 rgba(255,255,255,0.65);
+}
+
+body.dark-mode .retro-btn {
+  color: #efefef;
+  background: linear-gradient(180deg, #3a3a3a 0%, #2a2a2a 100%);
+  border-color: #4a4a4a;
+  box-shadow: 0 2px 0 #1f1f1f, inset 0 1px 0 rgba(255,255,255,0.05);
+}
+
+/* Knob */
+.retro-knob {
+  display: grid;
+  grid-template-columns: 1fr;
+  justify-items: center;
+  align-items: center;
+  gap: 6px;
+}
+.retro-knob label {
+  font-size: 9px;
+  color: #444;
+}
+body.dark-mode .retro-knob label { color: #e6e6e6; }
+
+/* Styled range as a vertical knob */
+#retro-volume {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, #d2d2d2 0 42%, transparent 43%),
+    conic-gradient(#ffb12e var(--angle, 65%), #c9c9c9 0);
+  border: 1px solid #bdbdbd;
+  box-shadow: inset 0 2px 6px rgba(0,0,0,0.3), 0 1px 0 rgba(255,255,255,0.7);
+  transform: rotate(-135deg);
+}
+
+body.dark-mode #retro-volume {
+  background:
+    radial-gradient(circle at 50% 50%, #444 0 42%, transparent 43%),
+    conic-gradient(#4fd28d var(--angle, 65%), #3a3a3a 0);
+  border-color: #4a4a4a;
+}
+
+#retro-volume::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 0;
+  height: 0;
+}
+#retro-volume::-moz-range-thumb {
+  width: 0;
+  height: 0;
+  border: none;
+}
+
+#retro-volume::before {
+  content: '';
+  position: absolute;
+  width: 2px; height: 8px;
+  background: #1a1a1a;
+  top: 4px; left: 50%;
+  transform: translateX(-50%);
+  border-radius: 1px;
+}
+body.dark-mode #retro-volume::before{ background:#e6e6e6; }
+
+.retro-knob { position: relative; }
+
+@media (max-width: 480px) {
+  .retro-chassis { width: 260px; }
+  .retro-btn { width: 40px; }
+}
   outline: none;
 }
 

--- a/assets/js/retro-miniplayer.js
+++ b/assets/js/retro-miniplayer.js
@@ -1,0 +1,235 @@
+// Retro Mini Music Player — uses retro-sound via ESM CDN
+// Arcade-style chiptune loops without any assets
+// Autoplay is gated behind user interaction per browser policy
+
+import { Sound, WhiteNoise } from 'https://esm.sh/retro-sound@1.0.4';
+
+const root = document.getElementById('retro-miniplayer');
+const playBtn = document.getElementById('retro-play');
+const prevBtn = document.getElementById('retro-prev');
+const nextBtn = document.getElementById('retro-next');
+const volKnob = document.getElementById('retro-volume');
+const trackLabel = document.getElementById('retro-track');
+
+let AC;              // AudioContext (lazy)
+let master;          // Master Gain
+let isPlaying = false;
+let currentIdx = 0;
+let currentTrackCtl = null;
+
+function ensureAudio() {
+  if (!AC) {
+    AC = new (window.AudioContext || window.webkitAudioContext)();
+    master = AC.createGain();
+    master.gain.value = (Number(volKnob?.value ?? 65)) / 100;
+    master.connect(AC.destination);
+  }
+}
+
+function updateVolAngle(v) {
+  // v is 0..100 → percentage of the conic gradient fill
+  const pct = Math.max(0, Math.min(100, v));
+  volKnob.style.setProperty('--angle', pct + '%');
+}
+
+function setVolume(v) {
+  if (master) master.gain.setTargetAtTime(v, AC.currentTime, 0.01);
+  updateVolAngle(v * 100);
+}
+
+// Utility: play a short note with quick decay
+function blip(note = 'A4', {
+  type = 'square',
+  volume = 0.9,
+  decay = 0.22,
+  mods = [],
+  filter = null,
+} = {}) {
+  const s = new Sound(AC, type);
+  mods.forEach(m => s.withModulator(m.type, m.depth, m.rate, m.param));
+  if (filter) s.withFilter(filter.type, filter.freq);
+  s.toDestination(master);
+  // Resume context in case it was suspended
+  AC.resume();
+  s.play(note).rampToVolumeAtTime(0, decay).waitDispose();
+}
+
+// Utility: simple noise percussion tap
+function tap({ cutoff = 8000, decay = 0.12 } = {}) {
+  const n = new WhiteNoise(AC).withFilter('lowpass', cutoff).toDestination(master);
+  AC.resume();
+  n.play().rampFilterFreqAtTime(1000, decay * 0.5).rampToVolumeAtTime(0, decay).waitDispose();
+}
+
+// Sequencer helper — schedules setInterval ticks for a pattern
+function makeLooper({ name, steps, tempoBPM = 140 }) {
+  // 8th-note grid by default
+  const stepMs = 60000 / (tempoBPM * 2);
+  let i = 0;
+  let t = null;
+
+  return {
+    name,
+    start() {
+      if (t) return; // already running
+      // Prime one immediate tick
+      tick();
+      t = setInterval(tick, stepMs);
+    },
+    stop() {
+      if (t) clearInterval(t), (t = null);
+    }
+  };
+
+  function tick() {
+    const step = steps[i % steps.length];
+    // step can be array (poly) or string note or function
+    if (typeof step === 'function') {
+      step();
+    } else if (Array.isArray(step)) {
+      step.forEach(ev => playEv(ev));
+    } else {
+      playEv(step);
+    }
+    i++;
+  }
+
+  function playEv(ev) {
+    if (!ev || ev === '-') return; // rest
+    if (typeof ev === 'string') {
+      blip(ev, { type: 'square', decay: 0.18, mods: [{ type: 'square', depth: 8, rate: 320, param: 'detune' }] });
+      return;
+    }
+    // object-based
+    const { note = 'A4', type = 'square', decay = 0.2, volume = 0.9, mods = [], filter = null, noise = false } = ev;
+    if (noise) { tap({ cutoff: 6000, decay: 0.08 }); return; }
+    blip(note, { type, decay, volume, mods, filter });
+  }
+}
+
+// Five loopable arcade-y patterns
+function trackRetroRacer() {
+  return makeLooper({
+    name: 'Retro Racer',
+    tempoBPM: 152,
+    steps: [
+      { note: 'E4' }, '-', { note: 'G4' }, { note: 'A4' }, '-', { note: 'B4' }, { note: 'E5' }, '-','-','noise','-','-'
+    ].map(s => (s === 'noise' ? { noise: true } : s))
+  });
+}
+
+function trackSpacePatrol() {
+  return makeLooper({
+    name: 'Space Patrol',
+    tempoBPM: 132,
+    steps: [
+      { note: 'A3', type: 'triangle', decay: 0.22 }, '-', { note: 'E4', type: 'triangle', decay: 0.22 }, '-',
+      { note: 'A4', type: 'triangle', decay: 0.22 }, '-', { note: 'C5', type: 'triangle', decay: 0.22 }, '-',
+      '-', { noise: true }, '-','-'
+    ]
+  });
+}
+
+function trackPixelQuest() {
+  return makeLooper({
+    name: 'Pixel Quest',
+    tempoBPM: 160,
+    steps: [
+      ['C4','E4','G4'].map(n => ({ note: n, type: 'square', decay: 0.16 })), '-',
+      ['D4','F4','A4'].map(n => ({ note: n, type: 'square', decay: 0.16 })), '-','-','noise','-','-'
+    ].flatMap(step => step)
+      .map(s => (Array.isArray(s) ? s : s))
+  });
+}
+
+function trackDungeonCrawl() {
+  return makeLooper({
+    name: 'Dungeon Crawl',
+    tempoBPM: 118,
+    steps: [
+      { note: 'A3', type: 'sawtooth', decay: 0.25, filter: { type: 'lowpass', freq: 900 } }, '-',
+      { note: 'G3', type: 'sawtooth', decay: 0.25, filter: { type: 'lowpass', freq: 900 } }, '-',
+      { note: 'F3', type: 'sawtooth', decay: 0.25, filter: { type: 'lowpass', freq: 900 } }, '-', '-', { noise: true }
+    ]
+  });
+}
+
+function trackSkyInvaders() {
+  return makeLooper({
+    name: 'Sky Invaders',
+    tempoBPM: 170,
+    steps: [
+      { note: 'C5', type: 'square', decay: 0.12 }, { note: 'C6', type: 'square', decay: 0.12 }, '-', { noise: true },
+      { note: 'G5', type: 'square', decay: 0.12 }, { note: 'G6', type: 'square', decay: 0.12 }, '-', '-'
+    ]
+  });
+}
+
+const trackFactories = [
+  trackRetroRacer,
+  trackSpacePatrol,
+  trackPixelQuest,
+  trackDungeonCrawl,
+  trackSkyInvaders,
+];
+
+function playIndex(idx) {
+  ensureAudio();
+  AC.resume();
+  if (currentTrackCtl) currentTrackCtl.stop();
+  currentIdx = (idx + trackFactories.length) % trackFactories.length;
+  currentTrackCtl = trackFactories[currentIdx]();
+  trackLabel.textContent = currentTrackCtl.name;
+  currentTrackCtl.start();
+  isPlaying = true;
+  root.classList.add('playing');
+  playBtn.textContent = '⏸';
+}
+
+function togglePlay() {
+  ensureAudio();
+  if (!isPlaying) {
+    playIndex(currentIdx);
+  } else {
+    // Pause = stop loop; resume starts from pattern beginning
+    if (currentTrackCtl) currentTrackCtl.stop();
+    isPlaying = false;
+    root.classList.remove('playing');
+    playBtn.textContent = '▶';
+  }
+}
+
+playBtn?.addEventListener('click', async () => {
+  ensureAudio();
+  try { await AC.resume(); } catch {}
+  togglePlay();
+});
+
+prevBtn?.addEventListener('click', async () => {
+  ensureAudio();
+  try { await AC.resume(); } catch {}
+  playIndex(currentIdx - 1);
+});
+
+nextBtn?.addEventListener('click', async () => {
+  ensureAudio();
+  try { await AC.resume(); } catch {}
+  playIndex(currentIdx + 1);
+});
+
+volKnob?.addEventListener('input', (e) => {
+  const v = Number(e.target.value || 65);
+  if (master && AC) setVolume(v / 100);
+  else updateVolAngle(v);
+});
+
+// Initialize knob visual
+updateVolAngle(Number(volKnob?.value ?? 65));
+
+// Helpful: allow starting from keyboard (Enter/Space) when focusing the controls
+playBtn?.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    playBtn.click();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link rel="icon" type="image/png" href="assets/images/favicon.png">
     <link rel="apple-touch-icon" href="assets/images/apple-touch-icon.png">
     <link href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@300;400;600" rel="stylesheet">
+    <!-- Retro arcade font for mini-player -->
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
@@ -424,7 +426,31 @@
             navigateToTab('blog');
         }
     });
-
     </script>
+
+    <!-- Retro Mini Music Player -->
+    <div id="retro-miniplayer" class="retro-miniplayer" aria-live="polite">
+      <div class="retro-chassis">
+        <div class="retro-top">
+          <span class="retro-title">arcade</span>
+          <span class="retro-led" aria-hidden="true"></span>
+        </div>
+        <div class="retro-display">
+          <span id="retro-track">Press ▶ to start</span>
+        </div>
+        <div class="retro-controls">
+          <button id="retro-prev" class="retro-btn" aria-label="Previous" type="button">⏮</button>
+          <button id="retro-play" class="retro-btn primary" aria-label="Play/Pause" type="button">▶</button>
+          <button id="retro-next" class="retro-btn" aria-label="Next" type="button">⏭</button>
+          <div class="retro-knob">
+            <label for="retro-volume">vol</label>
+            <input id="retro-volume" type="range" min="0" max="100" value="65" step="1" aria-label="Volume">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mini-player logic -->
+    <script type="module" src="assets/js/retro-miniplayer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR adds a bottom-right retro-styled mini music player to the site.\n\nHighlights\n- Uses retro-sound (via esm.sh) to synthesize 5 loopable arcade-style chiptune tracks (no audio assets).\n- Retro UI: LED indicator, 7-seg-like display, play/pause, prev/next, and a volume knob.\n- Works in light/dark modes and is self-contained (index.html + styles.css + assets/js/retro-miniplayer.js).\n\nImplementation\n- index.html: adds the player markup, arcade font, and a module script.\n- assets/css/styles.css: adds the retro chassis, buttons, LED, display, and knob styling.\n- assets/js/retro-miniplayer.js: integrates retro-sound; schedules sequences; lazy AudioContext init.\n\nEvidence\n- Git sync: fetch/pull fast-forwarded from origin/main.\n- Dependencies: none (static site).\n- Toolchains: node v20.12.1; npm 10.5.0; python3 3.10.13.\n\nNotes\n- Browser autoplay is respected: audio starts after user interaction (play button).\n\nRequest\n- Please review styling and positioning; adjust copy if you prefer different track names.\n