### PR TITLE
feat: CLI terminal redesign

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -203,7 +203,7 @@ a:hover {
 
 .terminal {
     width: 100%;
-    max-width: 800px;
+    max-width: 1000px;
     height: 80vh;
     max-height: 700px;
     display: flex;
@@ -250,6 +250,17 @@ a:hover {
     color: var(--text-secondary);
     flex: 1;
     text-align: center;
+}
+
+.title-link {
+    color: var(--accent);
+    text-decoration: none;
+    transition: color 0.15s ease;
+}
+
+.title-link:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
 }
 
 .title-actions {
@@ -342,6 +353,15 @@ a:hover {
     font-weight: 600;
 }
 
+#output .white {
+    color: var(--text-primary);
+}
+
+#output .bold.white {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
 #output a {
     color: var(--link);
 }
@@ -354,6 +374,9 @@ a:hover {
     font-size: 10px;
     line-height: 1.1;
     letter-spacing: -0.5px;
+    white-space: pre;
+    overflow-x: auto;
+    display: block;
 }
 
 /* ===== INPUT LINE ===== */
@@ -406,15 +429,52 @@ a:hover {
     50% { opacity: 0; }
 }
 
-/* ===== THEME SWITCHER ===== */
-.theme-switcher {
+/* ===== TERMINAL STATUS BAR ===== */
+.terminal-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-xs) var(--space-md);
+    background: var(--bg-tertiary);
+    border-top: 1px solid var(--border);
+    font-size: 11px;
+    color: var(--text-muted);
+    user-select: none;
+}
+
+.status-left,
+.status-center,
+.status-right {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+}
+
+.status-center {
+    color: var(--text-muted);
+}
+
+.status-hint {
+    opacity: 0.7;
+}
+
+.status-sep {
+    color: var(--border-strong);
+}
+
+.status-model {
+    color: var(--accent);
+}
+
+/* ===== COMMAND SHORTCUTS ===== */
+.command-shortcuts {
     display: flex;
     justify-content: center;
     gap: var(--space-sm);
     margin-top: var(--space-lg);
 }
 
-.theme-btn {
+.cmd-shortcut {
     padding: var(--space-xs) var(--space-md);
     background: transparent;
     border: 1px solid var(--border);
@@ -426,13 +486,14 @@ a:hover {
     transition: all 0.15s ease;
 }
 
-.theme-btn:hover {
+.cmd-shortcut:hover {
     background: var(--bg-hover);
     color: var(--text-primary);
     border-color: var(--border-strong);
 }
 
-.theme-btn.active {
+.cmd-shortcut:active,
+.cmd-shortcut.active {
     background: var(--accent);
     color: var(--bg-primary);
     border-color: var(--accent);
@@ -542,10 +603,20 @@ a:hover {
     
     .ascii-art {
         font-size: 8px;
+        white-space: pre;
+        overflow-x: auto;
     }
     
-    .theme-switcher {
+    .command-shortcuts {
         flex-wrap: wrap;
+    }
+    
+    .terminal-status {
+        font-size: 10px;
+    }
+    
+    .status-center {
+        display: none;
     }
     
     .music-player {
@@ -573,13 +644,24 @@ a:hover {
     }
     
     .ascii-art {
-        font-size: 6px;
+        font-size: 5px;
         letter-spacing: -1px;
+        white-space: pre;
+        overflow-x: auto;
     }
     
-    .theme-btn {
+    .cmd-shortcut {
         padding: var(--space-xs) var(--space-sm);
         font-size: 11px;
+    }
+    
+    .terminal-status {
+        font-size: 9px;
+        padding: var(--space-xs) var(--space-sm);
+    }
+    
+    .status-left {
+        display: none;
     }
 }
 
@@ -595,7 +677,7 @@ a:hover {
     outline: none;
 }
 
-.theme-btn:focus-visible,
+.cmd-shortcut:focus-visible,
 .help-btn:focus-visible,
 .music-btn:focus-visible {
     outline: 2px solid var(--accent);

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,299 +1,302 @@
 // Terminal state
 const state = {
-    history: [],
-    historyIndex: -1,
-    theme: localStorage.getItem('terminal-theme') || 'midnight'
+  history: [],
+  historyIndex: -1,
+  theme: localStorage.getItem("terminal-theme") || "midnight",
+  commandCount: 0,
 };
 
-// Content data
-const content = {
-    now: [
-        { text: 'founder & solo-gp', link: 'https://bensbites.com', linkText: "ben's bites" },
-        { text: 'i invest $100-200k into technical founders building technical tools' },
-        { text: 'head of dev rel @', link: 'https://factory.ai', linkText: 'Factory' },
-        { text: 'i write a newsletter where I show what tools im building with. 140k+ love it' },
-        { text: 'twin dad (1 of each btw)' }
-    ],
-    prev: [
-        { text: 'built and sold the biggest no-code community, makerpad, to zapier (in 18 months)' },
-        { text: 'scouted for a16z and invested in; gamma, cosine, julius.ai, lex, texel, llamaindex' },
-        { text: 'led the product hunt community & homepage, testing 1000s of products' },
-        { text: 'lived in china when I was in uni' }
-    ],
-    social: [
-        { text: 'twitter/x', link: 'https://x.com/bentossell' },
-        { text: 'linkedin', link: 'https://linkedin.com/in/ben-tossell-70453537' },
-        { text: 'github', link: 'https://github.com/bentossell' }
-    ],
-    contact: [
-        { text: 'email: ben@bensbites.com' },
-        { text: 'twitter: @bentossell' }
-    ]
-};
+// Fun vibes that rotate (changes every 8 seconds + on each command)
+const vibes = [
+  "building things",
+  "shipping fast",
+  "caffeinated ☕",
+  "in the zone",
+  "thinking...",
+  "exploring ideas",
+  "creating chaos",
+  "vibing",
+  "debugging life",
+  "ctrl+c ctrl+v",
+  "tabs not spaces",
+  "git push -f",
+  "rm -rf doubts",
+  "npm install coffee",
+  "making things",
+  "iterating",
+  "learning in public",
+  "writing code",
+  "breaking things",
+  "fixing things",
+  "one more feature...",
+  "refactoring",
+  "deep work",
+  "inbox zero (jk)",
+  "async mode",
+];
 
 // Available themes
-const themes = ['midnight', 'phosphor', 'amber', 'matrix', 'contrast'];
+const themes = ["midnight", "phosphor", "amber", "matrix", "contrast"];
 
 // Commands registry
 const commands = {
-    help: {
-        desc: 'show available commands',
-        fn: () => {
-            const lines = [
-                '',
-                '  <span class="accent">Available Commands:</span>',
-                '',
-                '  <span class="cmd">help</span>          show this help message',
-                '  <span class="cmd">whoami</span>        who is ben tossell',
-                '  <span class="cmd">now</span>           what im currently doing',
-                '  <span class="cmd">prev</span>          previous work & history',
-                '  <span class="cmd">investments</span>   my investment portfolio',
-                '  <span class="cmd">tools</span>         tools i use daily',
-                '  <span class="cmd">blog</span>          blog posts',
-                '  <span class="cmd">social</span>        social links',
-                '  <span class="cmd">contact</span>       get in touch',
-                '  <span class="cmd">theme</span>         list available themes',
-                '  <span class="cmd">theme [name]</span>  switch theme',
-                '  <span class="cmd">clear</span>         clear the terminal',
-                '  <span class="cmd">music</span>         toggle music player',
-                ''
-            ];
-            return lines.join('\n');
-        }
+  help: {
+    desc: "show available commands",
+    fn: () => {
+      const lines = [
+        "",
+        '  <span class="bold white">Available Commands</span>',
+        "",
+        '  <span class="cmd">help</span>          show this help message',
+        '  <span class="cmd">whoami</span>        who is ben tossell',
+        '  <span class="cmd">now</span>           what im doing',
+        '  <span class="cmd">prev</span>          previous work',
+        '  <span class="cmd">investments</span>   my investments',
+        '  <span class="cmd">tools</span>         tools i use daily',
+        '  <span class="cmd">models</span>        ai models i use',
+        '  <span class="cmd">contact</span>       find me',
+        '  <span class="cmd">theme</span>         list available themes',
+        '  <span class="cmd">theme [name]</span>  switch theme',
+        '  <span class="cmd">clear</span>         clear the terminal',
+        '  <span class="cmd">music</span>         toggle music player',
+        "",
+        '  <span class="muted">tip: shift+tab to cycle themes</span>',
+        "",
+      ];
+      return lines.join("\n");
     },
-    whoami: {
-        desc: 'who is ben tossell',
-        fn: () => {
-            return `
-  <span class="accent">Ben Tossell</span>
+  },
+  whoami: {
+    desc: "who is ben tossell",
+    fn: () => {
+      return `
+  <span class="bold white">Ben Tossell</span> <span class="muted">[2025]</span>
+  ┌────────────────────────────────────────────────┐
+  │  head of devrel      <a href="https://factory.ai" target="_blank" rel="noopener">Factory</a>                   │
+  │  investor & writer   <a href="https://bensbites.com" target="_blank" rel="noopener">Ben's Bites</a>               │
+  │  twin dad                                      │
+  └────────────────────────────────────────────────┘
 
-  Builder, investor, and writer based in the UK.
-  
-  I build tools, invest in technical founders, and write about
-  what I'm learning along the way. Previously built Makerpad
-  (acquired by Zapier) and led community at Product Hunt.
-  
-  Type <span class="cmd">now</span> to see what I'm currently up to.
+  i'm technically not technical, but technical enough to not be
+  truly non-technical.
+
+  technical, non-technical member of staff.
+
+  type <span class="cmd">now</span> to see what i'm currently up to.
 `;
-        }
     },
-    about: {
-        desc: 'alias for whoami',
-        fn: () => commands.whoami.fn()
+  },
+  about: {
+    desc: "alias for whoami",
+    fn: () => commands.whoami.fn(),
+  },
+  now: {
+    desc: "current activities",
+    fn: () => {
+      return `
+  <span class="bold white">now:</span>
+
+  • about to have baby number 3
+  • shipping on github <a href="https://github.com/bentossell" target="_blank" rel="noopener">/bentossell</a> & <a href="https://github.com/factory-ben" target="_blank" rel="noopener">/factory-ben</a>
+  • investing $100k into devtools & infra
+  • writing <a href="https://bensbites.com" target="_blank" rel="noopener">ben's bites</a> newsletter
+`;
     },
-    now: {
-        desc: 'current activities',
-        fn: () => {
-            let output = '\n  <span class="accent">Currently:</span>\n\n';
-            content.now.forEach(item => {
-                if (item.link) {
-                    output += `  • ${item.text} <a href="${item.link}" target="_blank" rel="noopener">${item.linkText}</a>\n`;
-                } else {
-                    output += `  • ${item.text}\n`;
-                }
-            });
-            return output;
-        }
+  },
+  prev: {
+    desc: "previous work",
+    fn: () => {
+      return `
+  <span class="bold white">previously:</span>
+
+  • founder, makerpad - sold to zapier (in 18 months) [2019-2021]
+  • sequoia & a16z scout [2021-2025]
+  • product hunt [2015-2017]
+`;
     },
-    prev: {
-        desc: 'previous work',
-        fn: () => {
-            let output = '\n  <span class="accent">Previously:</span>\n\n';
-            content.prev.forEach(item => {
-                output += `  • ${item.text}\n`;
-            });
-            return output;
-        }
+  },
+  history: {
+    desc: "alias for prev",
+    fn: () => commands.prev.fn(),
+  },
+  contact: {
+    desc: "find me",
+    fn: () => {
+      return `
+  <span class="bold white">contact:</span>
+
+  • <a href="https://x.com/bentossell" target="_blank" rel="noopener">twitter/x</a>
+  • <a href="https://linkedin.com/in/ben-tossell-70453537" target="_blank" rel="noopener">linkedin</a>
+  • <a href="https://github.com/bentossell" target="_blank" rel="noopener">github [personal]</a>
+  • <a href="https://discord.gg/zuudFXxg69" target="_blank" rel="noopener">droid discord</a>
+`;
     },
-    history: {
-        desc: 'alias for prev',
-        fn: () => commands.prev.fn()
+  },
+  social: {
+    desc: "alias for contact",
+    fn: () => commands.contact.fn(),
+  },
+  theme: {
+    desc: "change theme",
+    fn: (args) => {
+      if (!args || args.length === 0) {
+        let output = '\n  <span class="bold white">Available Themes</span>\n\n';
+        themes.forEach((t) => {
+          const current =
+            t === state.theme ? ' <span class="muted">(current)</span>' : "";
+          output += `  • <span class="cmd">${t}</span>${current}\n`;
+        });
+        output +=
+          '\n  usage: <span class="cmd">theme [name]</span> or shift+tab to cycle\n';
+        return output;
+      }
+      const themeName = args[0].toLowerCase();
+      if (themes.includes(themeName)) {
+        setTheme(themeName);
+        return `\n  theme changed to <span class="accent">${themeName}</span>\n`;
+      }
+      return `\n  <span class="error">unknown theme: ${themeName}</span>\n  type <span class="cmd">theme</span> to see available themes.\n`;
     },
-    social: {
-        desc: 'social links',
-        fn: () => {
-            let output = '\n  <span class="accent">Social Links:</span>\n\n';
-            content.social.forEach(item => {
-                output += `  • <a href="${item.link}" target="_blank" rel="noopener">${item.text}</a>\n`;
-            });
-            return output;
-        }
+  },
+  clear: {
+    desc: "clear terminal",
+    fn: () => {
+      setTimeout(() => {
+        document.getElementById("output").innerHTML = "";
+      }, 10);
+      return "";
     },
-    contact: {
-        desc: 'contact info',
-        fn: () => {
-            let output = '\n  <span class="accent">Contact:</span>\n\n';
-            content.contact.forEach(item => {
-                output += `  • ${item.text}\n`;
-            });
-            output += '\n  Feel free to reach out!\n';
-            return output;
-        }
+  },
+  investments: {
+    desc: "investment portfolio",
+    fn: () => {
+      return `
+  <span class="bold white">Investments</span>
+
+  • <a href="https://supabase.com" target="_blank" rel="noopener">supabase</a> <span class="muted">[seed]</span> → <span class="success">$5BN</span>
+  • <a href="https://gamma.app" target="_blank" rel="noopener">gamma</a> <span class="muted">[seed+ - a16z scout]</span> → <span class="success">$2.3BN</span> <span class="muted">[a16z led]</span>
+  • <a href="https://etched.com" target="_blank" rel="noopener">etched</a> <span class="muted">[seed+]</span> → <span class="success">$2.5BN</span>
+  • <a href="https://scribe.how" target="_blank" rel="noopener">scribe</a> <span class="muted">[seed]</span> → <span class="success">$1.3BN</span>
+  • <a href="https://factory.ai" target="_blank" rel="noopener">factory</a> <span class="muted">[seed]</span>
+  • <a href="https://sfcompute.com" target="_blank" rel="noopener">sf compute</a> <span class="muted">[pre-seed]</span>
+  • <a href="https://flutterflow.io" target="_blank" rel="noopener">flutterflow</a> <span class="muted">[seed]</span>
+  • <a href="https://wordware.ai" target="_blank" rel="noopener">wordware</a> <span class="muted">[pre-seed]</span>
+  • <a href="https://pika.art" target="_blank" rel="noopener">pika</a> <span class="muted">[series A]</span>
+  • <a href="https://crewai.com" target="_blank" rel="noopener">crewai</a> <span class="muted">[seed]</span>
+  • <a href="https://julius.ai" target="_blank" rel="noopener">julius</a> <span class="muted">[pre-seed]</span>
+`;
     },
-    theme: {
-        desc: 'change theme',
-        fn: (args) => {
-            if (!args || args.length === 0) {
-                let output = '\n  <span class="accent">Available Themes:</span>\n\n';
-                themes.forEach(t => {
-                    const current = t === state.theme ? ' <span class="muted">(current)</span>' : '';
-                    output += `  • <span class="cmd">${t}</span>${current}\n`;
-                });
-                output += '\n  Usage: <span class="cmd">theme [name]</span>\n';
-                return output;
-            }
-            const themeName = args[0].toLowerCase();
-            if (themes.includes(themeName)) {
-                setTheme(themeName);
-                return `\n  Theme changed to <span class="accent">${themeName}</span>\n`;
-            }
-            return `\n  <span class="error">Unknown theme: ${themeName}</span>\n  Type <span class="cmd">theme</span> to see available themes.\n`;
-        }
+  },
+  tools: {
+    desc: "tools i use",
+    fn: () => {
+      return `
+  <span class="bold white">tools:</span>
+
+  • <a href="https://factory.ai" target="_blank" rel="noopener">Factory</a> <span class="accent">[droid]</span>
+  • <a href="https://github.com" target="_blank" rel="noopener">GitHub</a>
+  • <a href="https://linear.app" target="_blank" rel="noopener">Linear</a>
+  • <a href="https://granola.ai" target="_blank" rel="noopener">Granola</a>
+  • <a href="https://ghostty.org" target="_blank" rel="noopener">Ghostty</a>
+`;
     },
-    clear: {
-        desc: 'clear terminal',
-        fn: () => {
-            setTimeout(() => {
-                document.getElementById('output').innerHTML = '';
-            }, 10);
-            return '';
-        }
+  },
+  models: {
+    desc: "ai models i use",
+    fn: () => {
+      return `
+  <span class="bold white">models:</span>
+
+  • opus 4.5 <span class="muted">[default model]</span>
+  • sonnet 4.5 <span class="muted">[usual daily driver]</span>
+  • gpt 5.1-codex <span class="muted">[bug fixes/code review]</span>
+`;
     },
-    investments: {
-        desc: 'investment portfolio',
-        fn: async () => {
-            appendOutput('\n  <span class="muted">Loading investments...</span>\n');
-            try {
-                const resp = await fetch('https://raw.githubusercontent.com/bentossell/bentossell/main/investments.md');
-                if (!resp.ok) throw new Error('Failed to fetch');
-                const text = await resp.text();
-                const formatted = formatMarkdown(text);
-                clearLastLine();
-                return '\n  <span class="accent">Investments:</span>\n\n' + formatted;
-            } catch (e) {
-                clearLastLine();
-                return '\n  <span class="error">Failed to load investments</span>\n';
-            }
-        }
+  },
+  music: {
+    desc: "toggle music player",
+    fn: () => {
+      const player = document.getElementById("music-player");
+      if (player) {
+        player.classList.toggle("visible");
+        return player.classList.contains("visible")
+          ? "\n  music player shown. click play to start.\n"
+          : "\n  music player hidden.\n";
+      }
+      return '\n  <span class="error">music player not available</span>\n';
     },
-    tools: {
-        desc: 'tools i use',
-        fn: async () => {
-            appendOutput('\n  <span class="muted">Loading tools...</span>\n');
-            try {
-                const resp = await fetch('https://raw.githubusercontent.com/bentossell/bentossell/main/tools.md');
-                if (!resp.ok) throw new Error('Failed to fetch');
-                const text = await resp.text();
-                const formatted = formatMarkdown(text);
-                clearLastLine();
-                return '\n  <span class="accent">Tools I Use:</span>\n\n' + formatted;
-            } catch (e) {
-                clearLastLine();
-                return '\n  <span class="error">Failed to load tools</span>\n';
-            }
-        }
+  },
+  sudo: {
+    desc: "nice try",
+    fn: () =>
+      '\n  <span class="error">nice try, but you don\'t have sudo access here.</span>\n',
+  },
+  rm: {
+    desc: "nice try",
+    fn: (args) => {
+      if (args && args.join(" ").includes("-rf")) {
+        return '\n  <span class="error">NICE TRY! this terminal is protected.</span>\n';
+      }
+      return '\n  <span class="error">rm: command not available in this terminal</span>\n';
     },
-    blog: {
-        desc: 'blog posts',
-        fn: async (args) => {
-            if (args && args.length > 0) {
-                return await loadBlogPost(args[0]);
-            }
-            appendOutput('\n  <span class="muted">Loading blog...</span>\n');
-            try {
-                const resp = await fetch('https://raw.githubusercontent.com/bentossell/bentossell/main/blog/index.md');
-                if (!resp.ok) throw new Error('Failed to fetch');
-                const text = await resp.text();
-                const formatted = formatBlogIndex(text);
-                clearLastLine();
-                return '\n  <span class="accent">Blog Posts:</span>\n\n' + formatted + '\n  Type <span class="cmd">blog [slug]</span> to read a post.\n';
-            } catch (e) {
-                clearLastLine();
-                return '\n  <span class="error">Failed to load blog</span>\n';
-            }
-        }
+  },
+  exit: {
+    desc: "exit terminal",
+    fn: () =>
+      '\n  <span class="muted">there is no escape. you\'re stuck here with me.</span>\n',
+  },
+  vim: {
+    desc: "editor wars",
+    fn: () =>
+      '\n  <span class="accent">vim is great.</span> but this isn\'t that kind of terminal.\n',
+  },
+  emacs: {
+    desc: "editor wars",
+    fn: () => '\n  <span class="muted">emacs users... i see you.</span>\n',
+  },
+  ls: {
+    desc: "list files",
+    fn: () =>
+      '\n  README.md  investments.md  tools.md\n\n  <span class="muted">try: whoami, now, investments, tools</span>\n',
+  },
+  cat: {
+    desc: "cat file",
+    fn: (args) => {
+      if (!args || args.length === 0) {
+        return '\n  <span class="error">cat: missing file argument</span>\n';
+      }
+      const file = args[0].toLowerCase();
+      if (file.includes("readme")) {
+        return commands.whoami.fn();
+      }
+      if (file.includes("investment")) {
+        return commands.investments.fn();
+      }
+      if (file.includes("tool")) {
+        return commands.tools.fn();
+      }
+      return `\n  <span class="error">cat: ${args[0]}: no such file</span>\n`;
     },
-    music: {
-        desc: 'toggle music player',
-        fn: () => {
-            const player = document.getElementById('music-player');
-            if (player) {
-                player.classList.toggle('visible');
-                return player.classList.contains('visible') 
-                    ? '\n  Music player shown. Click play to start.\n' 
-                    : '\n  Music player hidden.\n';
-            }
-            return '\n  <span class="error">Music player not available</span>\n';
-        }
-    },
-    // Easter eggs
-    sudo: {
-        desc: 'nice try',
-        fn: () => '\n  <span class="error">Nice try, but you don\'t have sudo access here.</span>\n'
-    },
-    'rm': {
-        desc: 'nice try',
-        fn: (args) => {
-            if (args && args.join(' ').includes('-rf')) {
-                return '\n  <span class="error">NICE TRY! This terminal is protected.</span>\n';
-            }
-            return '\n  <span class="error">rm: command not available in this terminal</span>\n';
-        }
-    },
-    exit: {
-        desc: 'exit terminal',
-        fn: () => '\n  <span class="muted">There is no escape. You\'re stuck here with me.</span>\n'
-    },
-    vim: {
-        desc: 'editor wars',
-        fn: () => '\n  <span class="accent">Vim is great.</span> But this isn\'t that kind of terminal.\n'
-    },
-    emacs: {
-        desc: 'editor wars',
-        fn: () => '\n  <span class="muted">Emacs users... I see you.</span>\n'
-    },
-    ls: {
-        desc: 'list files',
-        fn: () => '\n  README.md  investments.md  tools.md  blog/\n\n  <span class="muted">Try: whoami, now, investments, tools, blog</span>\n'
-    },
-    cat: {
-        desc: 'cat file',
-        fn: (args) => {
-            if (!args || args.length === 0) {
-                return '\n  <span class="error">cat: missing file argument</span>\n';
-            }
-            const file = args[0].toLowerCase();
-            if (file.includes('readme')) {
-                return commands.whoami.fn();
-            }
-            if (file.includes('investment')) {
-                return commands.investments.fn();
-            }
-            if (file.includes('tool')) {
-                return commands.tools.fn();
-            }
-            return `\n  <span class="error">cat: ${args[0]}: No such file</span>\n`;
-        }
-    },
-    cd: {
-        desc: 'change directory',
-        fn: () => '\n  <span class="muted">You\'re already home.</span>\n'
-    },
-    pwd: {
-        desc: 'print working directory',
-        fn: () => '\n  /home/ben\n'
-    },
-    echo: {
-        desc: 'echo text',
-        fn: (args) => args ? '\n  ' + args.join(' ') + '\n' : '\n'
-    },
-    date: {
-        desc: 'show date',
-        fn: () => '\n  ' + new Date().toString() + '\n'
-    },
-    neofetch: {
-        desc: 'system info',
-        fn: () => `
+  },
+  cd: {
+    desc: "change directory",
+    fn: () => '\n  <span class="muted">you\'re already home.</span>\n',
+  },
+  pwd: {
+    desc: "print working directory",
+    fn: () => "\n  /home/ben\n",
+  },
+  echo: {
+    desc: "echo text",
+    fn: (args) => (args ? "\n  " + args.join(" ") + "\n" : "\n"),
+  },
+  date: {
+    desc: "show date",
+    fn: () => "\n  " + new Date().toString() + "\n",
+  },
+  neofetch: {
+    desc: "system info",
+    fn: () => `
   <span class="accent">       _</span>          ben@tossell
   <span class="accent">      (_)</span>         -----------
   <span class="accent">   ___ _  ___</span>     OS: Human 1.0
@@ -301,246 +304,238 @@ const commands = {
   <span class="accent">  \\__ \\ |  __/</span>    Kernel: Coffee-powered
   <span class="accent">  |___/_|\\___|</span>    Uptime: ${getAge()} years
                     Shell: bash
-                    Terminal: ben.tossell
-`
-    }
+                    Terminal: bentossell
+`,
+  },
 };
 
 function getAge() {
-    const birth = new Date(1991, 0, 1);
-    const now = new Date();
-    return Math.floor((now - birth) / (365.25 * 24 * 60 * 60 * 1000));
-}
-
-function formatMarkdown(text) {
-    const lines = text.split('\n');
-    let output = '';
-    lines.forEach(line => {
-        let formatted = line
-            .replace(/^### (.+)$/, '<span class="accent">$1</span>')
-            .replace(/^## (.+)$/, '<span class="accent">$1</span>')
-            .replace(/^# (.+)$/, '<span class="accent">$1</span>')
-            .replace(/\*\*(.+?)\*\*/g, '<span class="bold">$1</span>')
-            .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
-            .replace(/^- (.+)$/, '  • $1')
-            .replace(/^\* (.+)$/, '  • $1');
-        output += '  ' + formatted + '\n';
-    });
-    return output;
-}
-
-function formatBlogIndex(text) {
-    const lines = text.split('\n');
-    let output = '';
-    const postPattern = /\[([^\]]+)\]\(\/blog\/posts\/([^)]+)\)/;
-    lines.forEach(line => {
-        const match = line.match(postPattern);
-        if (match) {
-            const title = match[1];
-            const slug = match[2].replace('.md', '');
-            output += `  • <span class="cmd">${slug}</span> - ${title}\n`;
-        }
-    });
-    return output || '  No posts found.\n';
-}
-
-async function loadBlogPost(slug) {
-    appendOutput('\n  <span class="muted">Loading post...</span>\n');
-    try {
-        const resp = await fetch(`https://raw.githubusercontent.com/bentossell/bentossell/main/blog/posts/${slug}.md`);
-        if (!resp.ok) throw new Error('Not found');
-        const text = await resp.text();
-        const content = text.replace(/^---[\s\S]*?---\n/, '');
-        const formatted = formatMarkdown(content);
-        clearLastLine();
-        return '\n' + formatted;
-    } catch (e) {
-        clearLastLine();
-        return `\n  <span class="error">Post not found: ${slug}</span>\n  Type <span class="cmd">blog</span> to see available posts.\n`;
-    }
+  const birth = new Date(1990, 7, 21);
+  const now = new Date();
+  return Math.floor((now - birth) / (365.25 * 24 * 60 * 60 * 1000));
 }
 
 function clearLastLine() {
-    const output = document.getElementById('output');
-    const lines = output.innerHTML.split('\n');
-    lines.pop();
-    lines.pop();
-    output.innerHTML = lines.join('\n');
+  const output = document.getElementById("output");
+  const lines = output.innerHTML.split("\n");
+  lines.pop();
+  lines.pop();
+  output.innerHTML = lines.join("\n");
 }
 
 function appendOutput(text) {
-    const output = document.getElementById('output');
-    output.innerHTML += text;
-    scrollToBottom();
+  const output = document.getElementById("output");
+  output.innerHTML += text;
+  scrollToBottom();
 }
 
 function scrollToBottom() {
-    const terminal = document.getElementById('terminal-body');
-    terminal.scrollTop = terminal.scrollHeight;
+  const terminal = document.getElementById("terminal-body");
+  terminal.scrollTop = terminal.scrollHeight;
 }
 
 function setTheme(themeName) {
-    document.body.className = `theme-${themeName}`;
-    state.theme = themeName;
-    localStorage.setItem('terminal-theme', themeName);
-    document.querySelectorAll('.theme-btn').forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.theme === themeName);
+  document.body.className = `theme-${themeName}`;
+  state.theme = themeName;
+  localStorage.setItem("terminal-theme", themeName);
+}
+
+function cycleTheme() {
+  const currentIndex = themes.indexOf(state.theme);
+  const nextIndex = (currentIndex + 1) % themes.length;
+  setTheme(themes[nextIndex]);
+  appendOutput(
+    `\n  <span class="muted">theme: ${themes[nextIndex]}</span>\n\n`,
+  );
+  scrollToBottom();
+}
+
+function updateUKTime() {
+  const timeEl = document.getElementById("status-time");
+  if (timeEl) {
+    const ukTime = new Date().toLocaleTimeString("en-GB", {
+      timeZone: "Europe/London",
+      hour: "2-digit",
+      minute: "2-digit",
     });
+    timeEl.textContent = ukTime + " UK";
+  }
+}
+
+function updateVibe() {
+  const vibeEl = document.getElementById("status-vibe");
+  if (vibeEl) {
+    const randomVibe = vibes[Math.floor(Math.random() * vibes.length)];
+    vibeEl.textContent = randomVibe;
+  }
 }
 
 async function executeCommand(input) {
-    const trimmed = input.trim();
-    if (!trimmed) return;
-    
-    state.history.push(trimmed);
-    state.historyIndex = state.history.length;
-    
-    const parts = trimmed.split(/\s+/);
-    const cmd = parts[0].toLowerCase();
-    const args = parts.slice(1);
-    
-    appendOutput(`<span class="prompt">$</span> ${escapeHtml(trimmed)}\n`);
-    
-    if (commands[cmd]) {
-        const result = await commands[cmd].fn(args);
-        if (result) {
-            appendOutput(result + '\n');
-        }
-    } else {
-        appendOutput(`\n  <span class="error">Command not found: ${cmd}</span>\n  Type <span class="cmd">help</span> for available commands.\n\n`);
+  const trimmed = input.trim();
+  if (!trimmed) return;
+
+  state.history.push(trimmed);
+  state.historyIndex = state.history.length;
+  state.commandCount++;
+
+  const parts = trimmed.split(/\s+/);
+  const cmd = parts[0].toLowerCase();
+  const args = parts.slice(1);
+
+  // Command text in orange
+  appendOutput(
+    `<span class="prompt">∴</span> <span class="accent">${escapeHtml(trimmed)}</span>\n`,
+  );
+
+  if (commands[cmd]) {
+    const result = await commands[cmd].fn(args);
+    if (result) {
+      appendOutput(result + "\n");
     }
-    
-    scrollToBottom();
+  } else {
+    appendOutput(
+      `\n  <span class="error">command not found: ${cmd}</span>\n  type <span class="cmd">help</span> for available commands.\n\n`,
+    );
+  }
+
+  scrollToBottom();
+  updateVibe();
 }
 
 function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
+  const div = document.createElement("div");
+  div.textContent = text;
+  return div.innerHTML;
 }
 
 function getCompletions(partial) {
-    const cmdNames = Object.keys(commands);
-    return cmdNames.filter(c => c.startsWith(partial.toLowerCase()));
+  const cmdNames = Object.keys(commands);
+  return cmdNames.filter((c) => c.startsWith(partial.toLowerCase()));
 }
 
 async function boot() {
-    const output = document.getElementById('output');
-    const lines = [
-        'Initializing terminal...',
-        'Loading modules... done',
-        'Connecting to ben.tossell... connected',
-        ''
-    ];
-    
-    for (const line of lines) {
-        output.innerHTML += `<span class="muted">${line}</span>\n`;
-        await sleep(150);
-        scrollToBottom();
-    }
-    
-    output.innerHTML += `<span class="accent ascii-art">
-  ██████╗   ███████╗  ███╗   ██╗
-  ██╔══██╗  ██╔════╝  ████╗  ██║
-  ██████╔╝  █████╗    ██╔██╗ ██║
-  ██╔══██╗  ██╔══╝    ██║╚██╗██║
-  ██████╔╝  ███████╗  ██║ ╚████║
-  ╚═════╝   ╚══════╝  ╚═╝  ╚═══╝
+  const output = document.getElementById("output");
+  const lines = [
+    "initializing terminal...",
+    "loading modules... done",
+    "connecting to ben.tossell... connected",
+    "",
+  ];
 
-  ████████╗  ██████╗   ███████╗  ███████╗  ███████╗  ██╗       ██╗
-  ╚══██╔══╝  ██╔═══██╗  ██╔════╝  ██╔════╝  ██╔════╝  ██║       ██║
-     ██║     ██║   ██║  ███████╗  ███████╗  █████╗    ██║       ██║
-     ██║     ██║   ██║  ╚════██║  ╚════██║  ██╔══╝    ██║       ██║
-     ██║     ╚██████╔╝  ███████║  ███████║  ███████╗  ███████╗  ███████╗
-     ╚═╝      ╚═════╝   ╚══════╝  ╚══════╝  ╚══════╝  ╚══════╝  ╚══════╝
-</span>
-`;
-    await sleep(100);
-    
-    output.innerHTML += `
-  Welcome to my terminal. Type <span class="cmd">help</span> to see available commands.
-
-`;
+  for (const line of lines) {
+    output.innerHTML += `<span class="muted">${line}</span>\n`;
+    await sleep(150);
     scrollToBottom();
-    
-    document.getElementById('command-input').focus();
+  }
+
+  output.innerHTML += `<span class="accent ascii-art">  ██████╗ ███████╗███╗   ██╗  ████████╗ ██████╗ ███████╗███████╗███████╗██╗     ██╗
+  ██╔══██╗██╔════╝████╗  ██║  ╚══██╔══╝██╔═══██╗██╔════╝██╔════╝██╔════╝██║     ██║
+  ██████╔╝█████╗  ██╔██╗ ██║     ██║   ██║   ██║███████╗███████╗█████╗  ██║     ██║
+  ██╔══██╗██╔══╝  ██║╚██╗██║     ██║   ██║   ██║╚════██║╚════██║██╔══╝  ██║     ██║
+  ██████╔╝███████╗██║ ╚████║     ██║   ╚██████╔╝███████║███████║███████╗███████╗███████╗
+  ╚═════╝ ╚══════╝╚═╝  ╚═══╝     ╚═╝    ╚═════╝ ╚══════╝╚══════╝╚══════╝╚══════╝╚══════╝</span>
+`;
+  await sleep(100);
+
+  output.innerHTML += `
+  builder. investor. dad.
+  welcome to my cli. type <span class="cmd">help</span> to see commands.
+
+`;
+  scrollToBottom();
+
+  document.getElementById("command-input").focus();
 }
 
 function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Initialize
-document.addEventListener('DOMContentLoaded', () => {
-    const input = document.getElementById('command-input');
-    const form = document.getElementById('command-form');
-    
-    setTheme(state.theme);
-    
-    form.addEventListener('submit', async (e) => {
-        e.preventDefault();
-        const value = input.value;
-        input.value = '';
-        await executeCommand(value);
-    });
-    
-    input.addEventListener('keydown', (e) => {
-        if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            if (state.historyIndex > 0) {
-                state.historyIndex--;
-                input.value = state.history[state.historyIndex] || '';
-            }
-        } else if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            if (state.historyIndex < state.history.length - 1) {
-                state.historyIndex++;
-                input.value = state.history[state.historyIndex] || '';
-            } else {
-                state.historyIndex = state.history.length;
-                input.value = '';
-            }
+document.addEventListener("DOMContentLoaded", () => {
+  const input = document.getElementById("command-input");
+  const form = document.getElementById("command-form");
+
+  setTheme(state.theme);
+  updateUKTime();
+  updateVibe();
+  setInterval(updateUKTime, 1000);
+  setInterval(updateVibe, 8000); // Change vibe every 8 seconds
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const value = input.value;
+    input.value = "";
+    await executeCommand(value);
+  });
+
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (state.historyIndex > 0) {
+        state.historyIndex--;
+        input.value = state.history[state.historyIndex] || "";
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (state.historyIndex < state.history.length - 1) {
+        state.historyIndex++;
+        input.value = state.history[state.historyIndex] || "";
+      } else {
+        state.historyIndex = state.history.length;
+        input.value = "";
+      }
+    } else if (e.shiftKey && e.key === "Tab") {
+      e.preventDefault();
+      cycleTheme();
+    } else if (e.key === "Tab" && !e.shiftKey) {
+      e.preventDefault();
+      const value = input.value.trim();
+      if (value) {
+        const completions = getCompletions(value);
+        if (completions.length === 1) {
+          input.value = completions[0] + " ";
+        } else if (completions.length > 1) {
+          appendOutput(
+            `<span class="prompt">∴</span> <span class="accent">${value}</span>\n`,
+          );
+          appendOutput(
+            `<span class="muted">${completions.join("  ")}</span>\n\n`,
+          );
+          scrollToBottom();
         }
-        else if (e.key === 'Tab') {
-            e.preventDefault();
-            const value = input.value.trim();
-            if (value) {
-                const completions = getCompletions(value);
-                if (completions.length === 1) {
-                    input.value = completions[0] + ' ';
-                } else if (completions.length > 1) {
-                    appendOutput(`<span class="prompt">$</span> ${value}\n`);
-                    appendOutput(`<span class="muted">${completions.join('  ')}</span>\n\n`);
-                    scrollToBottom();
-                }
-            }
-        }
-        else if (e.ctrlKey && e.key === 'l') {
-            e.preventDefault();
-            document.getElementById('output').innerHTML = '';
-        }
-        else if (e.ctrlKey && e.key === 'c') {
-            e.preventDefault();
-            appendOutput(`<span class="prompt">$</span> ${input.value}^C\n\n`);
-            input.value = '';
-        }
+      }
+    } else if (e.ctrlKey && e.key === "l") {
+      e.preventDefault();
+      document.getElementById("output").innerHTML = "";
+    } else if (e.ctrlKey && e.key === "c") {
+      e.preventDefault();
+      appendOutput(
+        `<span class="prompt">∴</span> <span class="accent">${input.value}</span>^C\n\n`,
+      );
+      input.value = "";
+    }
+  });
+
+  document.getElementById("terminal").addEventListener("click", (e) => {
+    if (e.target.tagName !== "A" && !e.target.closest(".cmd-shortcut")) {
+      input.focus();
+    }
+  });
+
+  document.querySelectorAll(".cmd-shortcut").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const cmd = btn.dataset.cmd;
+      if (cmd) {
+        await executeCommand(cmd);
+        input.focus();
+      }
     });
-    
-    document.getElementById('terminal').addEventListener('click', (e) => {
-        if (e.target.tagName !== 'A') {
-            input.focus();
-        }
-    });
-    
-    document.querySelectorAll('.theme-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-            setTheme(btn.dataset.theme);
-        });
-    });
-    
-    document.getElementById('help-btn')?.addEventListener('click', async () => {
-        await executeCommand('help');
-    });
-    
-    boot();
+  });
+
+  document.getElementById("help-btn")?.addEventListener("click", async () => {
+    await executeCommand("help");
+  });
+
+  boot();
 });

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
                     <span class="title-btn minimize"></span>
                     <span class="title-btn maximize"></span>
                 </div>
-                <span class="title-text">ben@tossell ~ bash</span>
+                <span class="title-text">~/bentossell <a href="https://factory.ai" target="_blank" rel="noopener" class="title-link">droid</a></span>
                 <div class="title-actions">
                     <button class="help-btn" id="help-btn" aria-label="Show help">?</button>
                 </div>
@@ -32,7 +32,7 @@
                 <div id="output" role="log" aria-live="polite"></div>
             </div>
             <div class="terminal-input">
-                <span class="input-prompt">$</span>
+                <span class="input-prompt">&gt;</span>
                 <form id="command-form" autocomplete="off">
                     <input 
                         type="text" 
@@ -45,14 +45,26 @@
                     >
                 </form>
             </div>
+            <div class="terminal-status">
+                <div class="status-left">
+                    <span class="status-item" id="status-vibe">building things</span>
+                </div>
+                <div class="status-center">
+                    <span class="status-hint">shift+tab to cycle themes</span>
+                </div>
+                <div class="status-right">
+                    <span class="status-item" id="status-time">--:--</span>
+                    <span class="status-sep">|</span>
+                    <span class="status-item status-model" title="my default model atm">Opus 4.5</span>
+                </div>
+            </div>
         </div>
         
-        <div class="theme-switcher">
-            <button class="theme-btn active" data-theme="midnight">midnight</button>
-            <button class="theme-btn" data-theme="phosphor">phosphor</button>
-            <button class="theme-btn" data-theme="amber">amber</button>
-            <button class="theme-btn" data-theme="matrix">matrix</button>
-            <button class="theme-btn" data-theme="contrast">contrast</button>
+        <div class="command-shortcuts">
+            <button class="cmd-shortcut" data-cmd="whoami">whoami</button>
+            <button class="cmd-shortcut" data-cmd="now">now</button>
+            <button class="cmd-shortcut" data-cmd="investments">investments</button>
+            <button class="cmd-shortcut" data-cmd="tools">tools</button>
         </div>
     </div>
 
@@ -96,53 +108,67 @@
         const prevBtn = document.getElementById('music-prev');
 
         const noteFreq = {
-            'C2': 65.41, 'D2': 73.42, 'E2': 82.41, 'F2': 87.31, 'G2': 98.00, 'A2': 110.00, 'B2': 123.47,
-            'C3': 130.81, 'D3': 146.83, 'E3': 164.81, 'F3': 174.61, 'G3': 196.00, 'A3': 220.00, 'B3': 246.94,
-            'C4': 261.63, 'D4': 293.66, 'E4': 329.63, 'F4': 349.23, 'G4': 392.00, 'A4': 440.00, 'B4': 493.88,
-            'C5': 523.25, 'D5': 587.33, 'E5': 659.25, 'F5': 698.46, 'G5': 783.99, 'A5': 880.00, 'B5': 987.77,
+            'C2': 65.41, 'C#2': 69.30, 'D2': 73.42, 'D#2': 77.78, 'E2': 82.41, 'F2': 87.31, 'F#2': 92.50, 'G2': 98.00, 'G#2': 103.83, 'A2': 110.00, 'A#2': 116.54, 'B2': 123.47,
+            'C3': 130.81, 'C#3': 138.59, 'D3': 146.83, 'D#3': 155.56, 'E3': 164.81, 'F3': 174.61, 'F#3': 185.00, 'G3': 196.00, 'G#3': 207.65, 'A3': 220.00, 'A#3': 233.08, 'B3': 246.94,
+            'C4': 261.63, 'C#4': 277.18, 'D4': 293.66, 'D#4': 311.13, 'E4': 329.63, 'F4': 349.23, 'F#4': 369.99, 'G4': 392.00, 'G#4': 415.30, 'A4': 440.00, 'A#4': 466.16, 'B4': 493.88,
+            'C5': 523.25, 'C#5': 554.37, 'D5': 587.33, 'D#5': 622.25, 'E5': 659.25, 'F5': 698.46, 'F#5': 739.99, 'G5': 783.99, 'G#5': 830.61, 'A5': 880.00, 'A#5': 932.33, 'B5': 987.77,
             'C6': 1046.50
         };
 
+        // Tracks with proper tempos and note patterns (using eighth notes as base unit)
         const tracks = [
             {
                 title: 'Tetris Theme',
-                bpm: 140,
+                bpm: 300, // Eighth notes at this speed = 150 BPM quarter notes
                 wave: 'square',
                 notes: [
-                    'E4', 'B3', 'C4', 'D4', 'C4', 'B3', 'A3', '-', 'A3', 'C4', 'E4', 'D4', 'C4', 'B3', '-',
-                    'C4', 'D4', 'E4', 'C4', 'A3', 'A3', '-', '-'
+                    'E5', 'B4', 'C5', 'D5', 'C5', 'B4', 'A4', 'A4', 'A4', 'C5', 'E5', 'E5', 'D5', 'C5', 'B4', 'B4',
+                    'B4', 'C5', 'D5', 'D5', 'E5', 'E5', 'C5', 'C5', 'A4', 'A4', 'A4', 'A4', '-', '-', '-', '-',
+                    'D5', 'D5', 'F5', 'A5', 'A5', 'G5', 'F5', 'E5', 'E5', 'C5', 'E5', 'E5', 'D5', 'C5', 'B4', 'B4',
+                    'B4', 'C5', 'D5', 'D5', 'E5', 'E5', 'C5', 'C5', 'A4', 'A4', 'A4', 'A4', '-', '-', '-', '-'
                 ]
             },
             {
                 title: 'Mario Theme',
-                bpm: 180,
+                bpm: 400, // Fast sixteenth-note feel
                 wave: 'square',
                 notes: [
-                    'E4', 'E4', '-', 'E4', '-', 'C4', 'E4', '-', 'G4', '-', '-', '-', 'G3', '-', '-', '-'
+                    'E5', 'E5', '-', 'E5', '-', '-', 'C5', 'E5', '-', '-', 'G5', '-', '-', '-', '-', '-',
+                    'G4', '-', '-', '-', '-', '-', '-', '-',
+                    'C5', '-', '-', 'G4', '-', '-', 'E4', '-', '-', '-', 'A4', '-', '-', 'B4', '-', '-',
+                    'A#4', 'A4', '-', '-', 'G4', 'E5', 'G5', 'A5', '-', '-', 'F5', 'G5', '-', '-', 'E5', '-',
+                    '-', 'C5', 'D5', 'B4', '-', '-', '-', '-'
                 ]
             },
             {
                 title: 'Zelda Lullaby',
-                bpm: 90,
+                bpm: 160, // Gentle tempo
                 wave: 'triangle',
                 notes: [
-                    'B4', 'D5', 'A4', '-', 'G4', 'A4', '-', 'B4', 'D5', 'A4', '-', '-', '-', '-', '-', '-'
+                    'B4', '-', 'D5', 'D5', 'A4', 'A4', '-', '-', 'G4', '-', 'A4', '-', '-', '-',
+                    'B4', '-', 'D5', 'D5', 'A4', 'A4', '-', '-', '-', '-', '-', '-', '-', '-'
                 ]
             },
             {
                 title: 'Pac-Man',
-                bpm: 160,
+                bpm: 340, // Snappy arcade feel
                 wave: 'sine',
                 notes: [
-                    'B4', 'B5', 'F5', 'D5', 'B5', 'F5', 'D5', '-', 'C5', 'C6', 'G5', 'E5', 'C6', 'G5', 'E5', '-'
+                    'B4', 'B5', 'F#5', 'D#5', 'B5', 'F#5', 'D#5', '-',
+                    'C5', 'C6', 'G5', 'E5', 'C6', 'G5', 'E5', '-',
+                    'B4', 'B5', 'F#5', 'D#5', 'B5', 'F#5', 'D#5', '-',
+                    'D#5', 'E5', 'F5', 'F5', 'F#5', 'G5', 'G#5', 'A5'
                 ]
             },
             {
                 title: 'Space Invaders',
-                bpm: 120,
+                bpm: 220, // Menacing march
                 wave: 'sawtooth',
                 notes: [
-                    'E3', '-', 'D3', '-', 'E3', '-', 'D3', '-', 'C3', '-', 'D3', '-', 'E3', '-', '-', '-'
+                    'A2', '-', 'B2', '-', 'C3', '-', 'B2', '-',
+                    'A2', '-', 'B2', '-', 'C3', '-', 'B2', '-',
+                    'G#2', '-', 'A2', '-', 'A#2', '-', 'A2', '-',
+                    'G#2', '-', 'A2', '-', 'A#2', '-', 'B2', '-'
                 ]
             }
         ];


### PR DESCRIPTION
Complete redesign of personal website to CLI terminal aesthetic.

## Features
- **Terminal UI** with macOS-style window chrome and traffic light buttons
- **5 themes**: midnight (default), phosphor, amber, matrix, contrast
  - Cycle with `shift+tab` or use `theme [name]` command
- **Interactive commands**: help, whoami, now, prev, investments, tools, models, contact
- **Status bar** with live UK time, rotating vibes (25 messages), model indicator
- **Command shortcuts** as clickable buttons (whoami, now, investments, tools)
- **Chiptune music player** with 5 retro game tracks (Tetris, Mario, Zelda, Pac-Man, Space Invaders)
- **ASCII art boot sequence** with BEN TOSSELL header
- **Command history** (arrow keys) and tab completion
- **Entered commands** display in orange accent color

## Content
- **whoami**: Head of DevRel at Factory, investor & writer Ben's Bites, twin dad
- **now**: Baby #3, GitHub accounts, investing $100k, newsletter
- **prev**: Makerpad → Zapier, a16z scout, Product Hunt
- **investments**: supabase, gamma, etched, scribe + others with valuations
- **tools**: Factory [droid], GitHub, Linear, Granola, Ghostty
- **models**: opus 4.5, sonnet 4.5, gpt 5.1-codex
- **contact**: twitter/x, linkedin, github, droid discord

## Technical
- Vanilla JS with no framework dependencies
- CSS custom properties for theming
- localStorage for theme persistence
- Web Audio API for music player
- Responsive design (mobile breakpoints at 768px, 480px)
- Terminal max-width: 1000px