### PR TITLE
fix: enable mobile browser address bar hiding with dvh units

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -164,12 +164,14 @@
 }
 
 /* ===== BASE STYLES ===== */
-html, body {
+html {
     height: 100%;
-    overflow: hidden;
 }
 
 body {
+    /* Use dvh for mobile browsers to account for address bar; fallback to vh */
+    min-height: 100vh;
+    min-height: 100dvh;
     font-family: var(--font-mono);
     font-size: var(--font-size);
     line-height: var(--line-height);
@@ -177,6 +179,9 @@ body {
     color: var(--text-primary);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Allow mobile browsers to detect scroll for address bar hide */
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 a {
@@ -196,7 +201,9 @@ a:hover {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    /* Use dvh for proper mobile viewport handling; fallback to vh */
     min-height: 100vh;
+    min-height: 100dvh;
     padding: var(--space-lg);
     background: var(--bg-primary);
 }
@@ -204,7 +211,9 @@ a:hover {
 .terminal {
     width: 100%;
     max-width: 1000px;
+    /* Use dvh for proper mobile viewport handling; fallback to vh */
     height: 80vh;
+    height: 80dvh;
     max-height: 700px;
     display: flex;
     flex-direction: column;
@@ -596,7 +605,9 @@ a:hover {
     }
     
     .terminal {
+        /* Use dvh for mobile address bar; fallback to vh */
         height: 85vh;
+        height: 85dvh;
         max-height: none;
         border-radius: var(--radius-md);
     }
@@ -635,7 +646,9 @@ a:hover {
     }
     
     .terminal {
+        /* Use dvh for mobile address bar; fallback to vh */
         height: 90vh;
+        height: 90dvh;
         border-radius: var(--radius-sm);
     }
     

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content">
     <title>ben tossell</title>
     <meta name="description" content="ben tossell's personal terminal - type 'help' to get started">
     <link rel="icon" type="image/png" href="assets/images/favicon.png">


### PR DESCRIPTION
- Replace vh with dvh (dynamic viewport height) units for proper mobile viewport handling when the address bar shows/hides
- Remove overflow:hidden from html/body to allow scroll detection
- Add interactive-widget=resizes-content to viewport meta tag
- Apply dvh fallbacks in responsive breakpoints for all screen sizes

Closes #81