### PR TITLE
fix: prevent mobile browser zoom on input focus

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -676,6 +676,10 @@ a:hover {
     .status-left {
         display: none;
     }
+    
+    #command-input {
+        font-size: 16px; /* Prevents mobile browser zoom on focus */
+    }
 }
 
 /* ===== ACCESSIBILITY ===== */


### PR DESCRIPTION
Sets input font-size to 16px on mobile to prevent iOS/Android auto-zoom when tapping the command input.